### PR TITLE
fix: return new object on commit transformation

### DIFF
--- a/conventional-changelog.js
+++ b/conventional-changelog.js
@@ -1,4 +1,4 @@
-// Copyright © 2022 Ory Corp
+// Copyright © 2024 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 
 "use strict"

--- a/conventional-recommended-bump.js
+++ b/conventional-recommended-bump.js
@@ -1,4 +1,4 @@
-// Copyright © 2022 Ory Corp
+// Copyright © 2024 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 
 "use strict"

--- a/email.js
+++ b/email.js
@@ -1,4 +1,4 @@
-// Copyright © 2022 Ory Corp
+// Copyright © 2024 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 
 "use strict"

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-// Copyright © 2022 Ory Corp
+// Copyright © 2024 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 
 "use strict"

--- a/parser-opts.js
+++ b/parser-opts.js
@@ -1,4 +1,4 @@
-// Copyright © 2022 Ory Corp
+// Copyright © 2024 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 
 "use strict"


### PR DESCRIPTION
I ran the changes against both an Kratos and Hydra where they work as expected, without any unexpected changes to the changelog's structure.